### PR TITLE
Use data science 2 image to fix dependencies and avoid need for a kernerl restart

### DIFF
--- a/02_data_exploration_and_feature_eng/02_data_exploration_and_feature_eng.ipynb
+++ b/02_data_exploration_and_feature_eng/02_data_exploration_and_feature_eng.ipynb
@@ -19,40 +19,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "import sagemaker\n",
-    "import sys\n",
-    "import IPython\n",
-    "\n",
-    "# Let's make sure we have the required version of the SM PySDK.\n",
-    "required_version = '2.49.2'\n",
-    "\n",
-    "def versiontuple(v):\n",
-    "    return tuple(map(int, (v.split(\".\"))))\n",
-    "\n",
-    "if versiontuple(sagemaker.__version__) < versiontuple(required_version):\n",
-    "    !{sys.executable} -m pip install -U sagemaker=={required_version}\n",
-    "\n",
-    "!{sys.executable} -m pip install -U numpy\n",
-    "!{sys.executable} -m pip install -U pandas\n",
-    "\n",
-    "IPython.Application.instance().kernel.do_shutdown(True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import sagemaker, pandas, numpy\n",
-    "print(sagemaker.__version__)\n",
-    "print(pandas.__version__)\n",
-    "print(numpy.__version__)"
+    "import warnings\n",
+    "\n",
+    "print('sagemaker version:', sagemaker.__version__)\n",
+    "print('pandas version:', pandas.__version__)\n",
+    "print('numpy version:', numpy.__version__)\n",
+    "\n",
+    "def versiontuple(v):\n",
+    "    return tuple(map(int, (v.split(\".\"))))\n",
+    "\n",
+    "if (versiontuple(sagemaker.__version__) < versiontuple('2.90.0')):\n",
+    "    warnings.warn('WARNING: this workshop was tested with sagemaker version 2.90.0 but you are using {}.'.format(  sagemaker.__version__) )\n",
+    "\n",
+    "if (versiontuple(pandas.__version__) < versiontuple('1.3.4') ):\n",
+    "    warnings.warn('WARNING: this workshop was tested with pandas version 1.3.4 but you are using {}.'.format( pandas.__version__))\n",
+    "    \n",
+    "if (versiontuple(numpy.__version__) < versiontuple('1.22.3')):\n",
+    "    warnings.warn('WARNING: this workshop was tested with numpy version 1.22.3 but you are using {}.'.format( numpy.__version__ ) )"
    ]
   },
   {
@@ -487,9 +474,9 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science)",
+   "display_name": "Python 3 (Data Science 2.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:eu-west-1:470317259841:image/datascience-1.0"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-38"
   },
   "language_info": {
    "codemirror_mode": {
@@ -501,7 +488,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/03_train_model/03_train_model.ipynb
+++ b/03_train_model/03_train_model.ipynb
@@ -20,34 +20,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "import sagemaker\n",
-    "import sys\n",
-    "import IPython\n",
-    "\n",
-    "# Let's make sure we have the required version of the SM PySDK.\n",
-    "required_version = '2.49.2'\n",
-    "\n",
-    "def versiontuple(v):\n",
-    "    return tuple(map(int, (v.split(\".\"))))\n",
-    "\n",
-    "if versiontuple(sagemaker.__version__) < versiontuple(required_version):\n",
-    "    !{sys.executable} -m pip install -U sagemaker=={required_version}\n",
-    "    IPython.Application.instance().kernel.do_shutdown(True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import sagemaker\n",
-    "print(sagemaker.__version__)"
+    "import warnings\n",
+    "\n",
+    "print('sagemaker version:', sagemaker.__version__)\n",
+    "\n",
+    "def versiontuple(v):\n",
+    "    return tuple(map(int, (v.split(\".\"))))\n",
+    "\n",
+    "if (versiontuple(sagemaker.__version__) < versiontuple('2.90.0')):\n",
+    "    warnings.warn('WARNING: this workshop was tested with sagemaker version 2.90.0 but you are using {}.'.format(  sagemaker.__version__) )"
    ]
   },
   {
@@ -214,9 +199,9 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science)",
+   "display_name": "Python 3 (Data Science 2.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:eu-west-1:470317259841:image/datascience-1.0"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-38"
   },
   "language_info": {
    "codemirror_mode": {
@@ -228,7 +213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/04_deploy_model/04_deploy_model.ipynb
+++ b/04_deploy_model/04_deploy_model.ipynb
@@ -22,34 +22,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "import sagemaker\n",
-    "import sys\n",
-    "import IPython\n",
-    "\n",
-    "# Let's make sure we have the required version of the SM PySDK.\n",
-    "required_version = '2.49.2'\n",
-    "\n",
-    "def versiontuple(v):\n",
-    "    return tuple(map(int, (v.split(\".\"))))\n",
-    "\n",
-    "if versiontuple(sagemaker.__version__) < versiontuple(required_version):\n",
-    "    !{sys.executable} -m pip install -U sagemaker=={required_version}\n",
-    "    IPython.Application.instance().kernel.do_shutdown(True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import sagemaker\n",
-    "print(sagemaker.__version__)"
+    "import warnings\n",
+    "\n",
+    "print('sagemaker version:', sagemaker.__version__)\n",
+    "\n",
+    "def versiontuple(v):\n",
+    "    return tuple(map(int, (v.split(\".\"))))\n",
+    "\n",
+    "if (versiontuple(sagemaker.__version__) < versiontuple('2.90.0')):\n",
+    "    warnings.warn('WARNING: this workshop was tested with sagemaker version 2.90.0 but you are using {}.'.format(  sagemaker.__version__) )"
+
    ]
   },
   {
@@ -346,9 +332,9 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science)",
+   "display_name": "Python 3 (Data Science 2.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:eu-west-1:470317259841:image/datascience-1.0"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-38"
   },
   "language_info": {
    "codemirror_mode": {
@@ -360,7 +346,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I changed the notebook metadata to use the new Data Science 2 image (ARN of the us-east-1 region) and replaced the code that installs sagemaker, pandas or numpy and restarts the kernel with a warning if the dependency versions are not met.

This way workshop participants can run through all cells without any errors.

Tested for module 2 - 4 in us-east-1


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
