### PR TITLE
Specify xgboost version to enable deployment

### DIFF
--- a/02_deploy/deploy.py
+++ b/02_deploy/deploy.py
@@ -145,7 +145,9 @@ def build_xgboost_sagemaker_model(role, booster):
         model_path="xgboost_model/",
         dependencies={"requirements": "requirements_inference.txt"},
         schema_builder=schema_builder,
-        role_arn=role)
+        role_arn=role,
+        image_uri=get_image_uri(framework="xgboost", region=current_region, version="1.7-1")
+        )
     
     return model_builder.build()
 

--- a/03_workflow/steps/register.py
+++ b/03_workflow/steps/register.py
@@ -108,7 +108,9 @@ def build_xgboost_sagemaker_model(role, booster):
         model_path="xgboost_model/",
         dependencies={"requirements": "requirements_inference.txt"},
         schema_builder=schema_builder,
-        role_arn=role)
+        role_arn=role,
+        image_uri=get_image_uri(framework="xgboost", region=current_region, version="1.7-1")
+        )
     
     return model_builder.build()
 


### PR DESCRIPTION
*Issue #, if available:* 
N/A

*Description of changes:* 
Modules 2 and 3 needed the version of xgboost specified in `ModelBuilder` during the endpoint deployment process. Otherwise it was throwing an error and preventing completion of the remaining modules.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
